### PR TITLE
Update to address (vSphere specific?) bug

### DIFF
--- a/transition.sh
+++ b/transition.sh
@@ -3,7 +3,7 @@
 # find out what status the cluster is in
 get_cluster_status(){
     local cluster=$1
-    status=$(kubectl get cluster $1 -o json | jq '.status.phase')
+    status=$(kubectl get cluster $1 -o json | jq '.status.controlPlaneInitialized')
     echo $status
 }
 
@@ -50,7 +50,7 @@ clusterstatus=NULL
 until [ $i -gt 60 ]
 do 
     clusterstatus=$(get_cluster_status $1)
-    if [[ $clusterstatus == '"Provisioned"' ]]
+    if [[ $clusterstatus == 'true' ]]
     then
         echo "Cluster has been provisioned"
         creds=$(get_creds $1)


### PR DESCRIPTION
vSphere clusters report cluster phase as "Provisioned" too quickly, causing an error in my current testing environment. This change waits for the status of `controlPlaneInitialized: true` to ensure that the yaml is applied after the control plane is ready.